### PR TITLE
Add syntax highlighting to README.md using GFM

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,55 +21,70 @@ Installation
 
  1. Add Linkify to your dependencies:
 
-        // composer.json
-
-        {
-           // ...
-           "require": {
-               // ...
-               "misd/linkify": "1.1.*"
-           }
-        }
+```javascript
+// composer.json
+{
+   // ...
+   "require": {
+       // ...
+       "misd/linkify": "1.1.*"
+   }
+}
+```
 
  2. Use Composer to download and install Linkify:
 
-        $ php composer.phar update misd/linkify
+```bash
+$ php composer.phar update misd/linkify
+```
 
 Usage
 -----
 
-        $linkify = new \Misd\Linkify\Linkify();
-        $text = 'This is my text containing a link to www.example.com.';
+```php
+$linkify = new \Misd\Linkify\Linkify();
+$text = 'This is my text containing a link to www.example.com.';
 
-        echo $linkify->process($text);
+echo $linkify->process($text);
+```
 
 Will output:
 
-        This is my text containing a link to <a href="http://www.example.com">www.example.com</a>.
+```html
+This is my text containing a link to <a href="http://www.example.com">www.example.com</a>.
+```
 
 ### Options
 
 Options set on the constructor will be applied to all links. Alternatively you can place the options on a method call. The latter will override the former.
 
-        $linkify = new \Misd\Linkify\Linkify(array('attr' => array('class' => 'foo')));
-        $text = 'This is my text containing a link to www.example.com.';
+```php
+$linkify = new \Misd\Linkify\Linkify(array('attr' => array('class' => 'foo')));
+$text = 'This is my text containing a link to www.example.com.';
 
-        echo $linkify->process($text);
+echo $linkify->process($text);
+```
 
 Will output:
 
-        This is my text containing a link to <a href="http://www.example.com" class="foo">www.example.com</a>.
+```html
+This is my text containing a link to <a href="http://www.example.com" class="foo">www.example.com</a>.
+```
 
 Whereas:
 
-        $linkify = new \Misd\Linkify\Linkify(array('attr' => array('class' => 'foo')));
-        $text = 'This is my text containing a link to www.example.com.';
+```php
+$linkify = new \Misd\Linkify\Linkify(array('attr' => array('class' => 'foo')));
+$text = 'This is my text containing a link to www.example.com.';
 
-        echo $linkify->process($text, array('attr' => array('class' => 'bar')));
+echo $linkify->process($text, array('attr' => array('class' => 'bar')));
+```
 
 Will output:
 
-        This is my text containing a link to <a href="http://www.example.com" class="bar">www.example.com</a>.
+```html
+This is my text containing a link to <a href="http://www.example.com" class="bar">www.example.com</a>.
+```
 
 Available options are:
 
@@ -77,7 +92,9 @@ Available options are:
 
 An associative array of HTML attributes to add to the link. For example:
 
-        array('attr' => array('class' => 'foo', 'style' => 'font-weight: bold; color: red;')
+```php
+array('attr' => array('class' => 'foo', 'style' => 'font-weight: bold; color: red;')
+```
 
 #### `callback`
 
@@ -85,7 +102,9 @@ A closure to call with each url match. The closure will be called for each URL f
 
 If the callback return a non-null value, this value replace the link in the resulting text. If null is returned, the usual `<a href="URL">CAPTION</a>` is used.
 
-        $linkify = new \Misd\Linkify\Linkify(array('callback' => function($url, $caption, $isEmail) {
-            return '<b>' . $caption . '</b>';
-        }));
-        echo $linkify->process('This link will be converted to bold: www.example.com.'));
+```php
+$linkify = new \Misd\Linkify\Linkify(array('callback' => function($url, $caption, $isEmail) {
+    return '<b>' . $caption . '</b>';
+}));
+echo $linkify->process('This link will be converted to bold: www.example.com.'));
+```


### PR DESCRIPTION
This proposed change make use of the [syntax highlighting feature](https://help.github.com/articles/github-flavored-markdown#syntax-highlighting "GitHub Flavored Markdown: Syntax highlighting") of the GitHub Flavored Markdown format in order to make the code examples of the README file more readable.