### PR TITLE
Allow callback to know about the used html attributes

### DIFF
--- a/src/Misd/Linkify/Linkify.php
+++ b/src/Misd/Linkify/Linkify.php
@@ -168,7 +168,7 @@ class Linkify implements LinkifyInterface
             }
 
             if (isset($options['callback'])) {
-                $cb = $options['callback']($match[0], $caption, false);
+                $cb = $options['callback']($match[0], $caption, false, $options['attr']);
                 if (!is_null($cb)) {
                     return $cb;
                 }
@@ -202,7 +202,7 @@ class Linkify implements LinkifyInterface
 
         $callback = function ($match) use ($options) {
             if (isset($options['callback'])) {
-                $cb = $options['callback']($match[0], $match[0], true);
+                $cb = $options['callback']($match[0], $match[0], true, $options['attr']);
                 if (!is_null($cb)) {
                     return $cb;
                 }


### PR DESCRIPTION
I've a situation where the code that sets the callback calls a wrapper around Linkify, and this wrapper sets the attributes. Thus my callback doesn't know about the attributes being used and can't apply them when building a new anchor.