### PR TITLE
Add an option to only linkify URLs that start with a scheme

### DIFF
--- a/src/Misd/Linkify/Linkify.php
+++ b/src/Misd/Linkify/Linkify.php
@@ -164,7 +164,11 @@ class Linkify implements LinkifyInterface
             $pattern = "~^(ht|f)tps?://~";
 
             if (0 === preg_match($pattern, $match[0])) {
-                $match[0] = 'http://' . $match[0];
+                if (array_key_exists('require_scheme', $options) && $options['require_scheme']) {
+                    return $caption;
+                } else {
+                    $match[0] = 'http://' . $match[0];
+                }
             }
 
             if (isset($options['callback'])) {


### PR DESCRIPTION
Adding a `require_scheme` option allows a user to disable auto-linking of things that look like URLs (e.g. `www.example.com`), so that only full URLs (e.g. `https://www.example.com`) are auto-linked. The scheme currently has to match `~^(ht|f)tps?://~`.

Example usage:
```php
$html = $linkify->processUrls($html, [
  'require_scheme' => true
]);
```