### PR TITLE
Fix catastrophic backtracking

### DIFF
--- a/src/Misd/Linkify/Linkify.php
+++ b/src/Misd/Linkify/Linkify.php
@@ -139,23 +139,23 @@ class Linkify implements LinkifyInterface
     {
         $pattern = '~(?xi)
               (?:
-                ((ht|f)tps?://)                    # scheme://
-                |                                  #   or
-                www\d{0,3}\.                       # "www.", "www1.", "www2." ... "www999."
-                |                                  #   or
-                www\-                              # "www-"
-                |                                  #   or
-                [a-z0-9.\-]+\.[a-z]{2,4}(?=/)      # looks like domain name followed by a slash
+                ((ht|f)tps?://)                      # scheme://
+                |                                    #   or
+                www\d{0,3}\.                         # "www.", "www1.", "www2." ... "www999."
+                |                                    #   or
+                www\-                                # "www-"
+                |                                    #   or
+                [a-z0-9.\-]+\.[a-z]{2,4}(?=/)        # looks like domain name followed by a slash
               )
-              (?:                                  # Zero or more:
-                [^\s()<>]+                         # Run of non-space, non-()<>
-                |                                  #   or
-                \(([^\s()<>]+|(\([^\s()<>]+\)))*\) # balanced parens, up to 2 levels
+              (?:                                    # Zero or more:
+                [^\s()<>]+                           # Run of non-space, non-()<>
+                |                                    #   or
+                \(([^\s()<>]+|(\([^\s()<>]+\)))*\)   # balanced parens, up to 2 levels
               )*
-              (?:                                  # End with:
-                \(([^\s()<>]+|(\([^\s()<>]+\)))*\) # balanced parens, up to 2 levels
-                |                                  #   or
-                [^\s`!\-()\[\]{};:\'".,<>?«»“”‘’]  # not a space or one of these punct chars
+              (?:                                    # End with:
+                \(([^\s()<>]+|(\([^\s()<>]+\)))*\)   # balanced parens, up to 2 levels
+                |                                    #   or
+                [^\s`!\-()\[\]{};:\'".,<>?«»“”‘’]    # not a space or one of these punct chars
               )
         ~';
 

--- a/src/Misd/Linkify/Linkify.php
+++ b/src/Misd/Linkify/Linkify.php
@@ -130,6 +130,9 @@ class Linkify implements LinkifyInterface
     /**
      * Add HTML links to URLs in plain text.
      *
+     * @see http://www.regular-expressions.info/catastrophic.html For more info on atomic-grouping,
+     *      used in this regex to prevent Catastrophic Backtracking.
+     *
      * @param string $text    Text to linkify.
      * @param array  $options Options, 'attr' key being the attributes to add to the links, with a preceding space.
      *
@@ -150,10 +153,10 @@ class Linkify implements LinkifyInterface
               (?:                                    # Zero or more:
                 [^\s()<>]+                           # Run of non-space, non-()<>
                 |                                    #   or
-                \(([^\s()<>]+|(\([^\s()<>]+\)))*\)   # balanced parens, up to 2 levels
+                \((?>[^\s()<>]+|(\([^\s()<>]+\)))*\) # balanced parens, up to 2 levels
               )*
               (?:                                    # End with:
-                \(([^\s()<>]+|(\([^\s()<>]+\)))*\)   # balanced parens, up to 2 levels
+                \((?>[^\s()<>]+|(\([^\s()<>]+\)))*\) # balanced parens, up to 2 levels
                 |                                    #   or
                 [^\s`!\-()\[\]{};:\'".,<>?«»“”‘’]    # not a space or one of these punct chars
               )

--- a/tests/data/url.json
+++ b/tests/data/url.json
@@ -227,6 +227,18 @@
                 ]
             },
             "expected": "<a href=\"http://www.example.com\" class=\"foo bar\" rel=\"nofollow\">www.example.com</a>"
+        },
+        {
+            "test": "https://www.example.com/a_(aaaaaaaaaaaaaaaa)",
+            "expected": "<a href=\"https://www.example.com/a_(aaaaaaaaaaaaaaaa)\">https://www.example.com/a_(aaaaaaaaaaaaaaaa)</a>"
+        },
+        {
+            "test": "https://www.example.com/a_(aaaaaaaaaaaaaaaaa)",
+            "expected": "<a href=\"https://www.example.com/a_(aaaaaaaaaaaaaaaaa)\">https://www.example.com/a_(aaaaaaaaaaaaaaaaa)</a>"
+        },
+        {
+            "test": "https://www.example.com/a_(aaaaaaaaaaaaaaaaa)a",
+            "expected": "<a href=\"https://www.example.com/a_(aaaaaaaaaaaaaaaaa)a\">https://www.example.com/a_(aaaaaaaaaaaaaaaaa)a</a>"
         }
     ]
 }


### PR DESCRIPTION
Fixes issue https://github.com/misd-service-development/php-linkify/issues/14 by applying atomic-grouping to prevent catastrophic backtracking.

Edge case:  
`https://www.example.com/a_(aaaaaaaaaaaaaaaaa)` with 17 chars inside parentheses results in a `PREG_BACKTRACK_LIMIT_ERROR`  

Similar strings result in a successful match
`https://www.example.com/a_(aaaaaaaaaaaaaaaa)` with 16 chars inside parentheses  
`https://www.example.com/a_(aaaaaaaaaaaaaaaaa)b` with 17 chars inside parentheses together with trailing character  

Tests have been added which address the now solved edge case together with its sibling cases.

The following fork already contains the fix: https://github.com/lode/php-linkify/