### PR TITLE
Add unicode support.

### DIFF
--- a/src/Misd/Linkify/Linkify.php
+++ b/src/Misd/Linkify/Linkify.php
@@ -160,7 +160,7 @@ class Linkify implements LinkifyInterface
                 |                                    #   or
                 [^\s`!\-()\[\]{};:\'".,<>?«»“”‘’]    # not a space or one of these punct chars
               )
-        ~';
+        ~u';
 
         $callback = function ($match) use ($options) {
             $caption = $match[0];
@@ -201,7 +201,7 @@ class Linkify implements LinkifyInterface
                 [A-Z0-9.-]+      # Domain
                 \.               # Dot
                 [A-Z]{2,4}       # Something
-        ~';
+        ~u';
 
         $callback = function ($match) use ($options) {
             if (isset($options['callback'])) {

--- a/tests/data/email.json
+++ b/tests/data/email.json
@@ -47,6 +47,10 @@
             "expected": "<a href=\"mailto:example@example.example.com\">example@example.example.com</a>."
         },
         {
+            "test": "example@example.example.com　",
+            "expected": "<a href=\"mailto:example@example.example.com\">example@example.example.com</a>　"
+        },
+        {
             "test": "(example@example.com)",
             "expected": "(<a href=\"mailto:example@example.com\">example@example.com</a>)"
         },

--- a/tests/data/email.json
+++ b/tests/data/email.json
@@ -51,6 +51,10 @@
             "expected": "<a href=\"mailto:example@example.example.com\">example@example.example.com</a>　"
         },
         {
+            "test": "Привет example@example.com!",
+            "expected": "Привет <a href=\"mailto:example@example.com\">example@example.com</a>!"
+        },
+        {
             "test": "(example@example.com)",
             "expected": "(<a href=\"mailto:example@example.com\">example@example.com</a>)"
         },

--- a/tests/data/url.json
+++ b/tests/data/url.json
@@ -43,6 +43,10 @@
             "expected": "<a href=\"http://www.example.com\">www.example.com</a>　"
         },
         {
+            "test": "Линк: https://ru.wikipedia.org/wiki/Футбол",
+            "expected": "Линк: <a href=\"https://ru.wikipedia.org/wiki/Футбол\">https://ru.wikipedia.org/wiki/Футбол</a>"
+        },
+        {
             "test": "(http://www.example.com/)",
             "expected": "(<a href=\"http://www.example.com/\">http://www.example.com/</a>)"
         },

--- a/tests/data/url.json
+++ b/tests/data/url.json
@@ -39,6 +39,10 @@
             "expected": "<a href=\"http://www.example.com/example/\">http://www.example.com/example/</a>"
         },
         {
+            "test": "www.example.com　",
+            "expected": "<a href=\"http://www.example.com\">www.example.com</a>　"
+        },
+        {
             "test": "(http://www.example.com/)",
             "expected": "(<a href=\"http://www.example.com/\">http://www.example.com/</a>)"
         },


### PR DESCRIPTION
While running Linkify over some Unicode text I've got struck by a weird issue where URLs with Unicode characters (especially blank characters) would result in a given text being transformed into binary string.

For example: 

````php
'http://www.example.com　　　　';
````

Notice at the end of the URL several blank Unicode characters. After running `process()` method, that string would be converted to binary string:

````php
b"""
<a href="http://www.example.com　　　　">http://www.example.com　　　　</a>
"""
````

Which really messes up output to the user.

This PR sets pattern used in `preg_replace_callback` to be in Unicode mode which handles strings correctly and above input would be converted to following string:

````php
"<a href="http://www.example.com">http://www.example.com</a>　　　　"
````