### PR TITLE
Smaller Tests - make avoidNonLinks test smaller. One assert per test.

### DIFF
--- a/tests/Misd/Linkify/Test/LinkifyTest.php
+++ b/tests/Misd/Linkify/Test/LinkifyTest.php
@@ -46,10 +46,19 @@ abstract class LinkifyTest extends TestCase
 
     public function ignoreProvider()
     {
-        return array(
-            array($this->loadData('ignore.json')),
-            array($this->loadData('ignore-options.json')),
-        );
+        $out = array();
+        foreach(array(
+                    $this->loadData('ignore.json'),
+                    $this->loadData('ignore-options.json'),
+                ) as $data) {
+            foreach($data['tests'] as $test) {
+                $out[] = array(
+                    $data['options'],
+                    $test,
+                );
+            }
+        }
+        return $out;
     }
 
     public function callbackProvider()

--- a/tests/Misd/Linkify/Test/ProcessEmailsTest.php
+++ b/tests/Misd/Linkify/Test/ProcessEmailsTest.php
@@ -73,12 +73,9 @@ class ProcessEmailsTest extends LinkifyTest
      * @test
      * @dataProvider ignoreProvider
      */
-    public function avoidNonLinks(array $data)
+    public function avoidNonLinks(array $options, $test)
     {
-        $linkify = new Linkify($data['options']);
-
-        foreach ($data['tests'] as $test) {
-            $this->assertEquals($test, $linkify->processEmails($test));
-        }
+        $linkify = new Linkify($options);
+        $this->assertEquals($test, $linkify->processEmails($test));
     }
 }

--- a/tests/Misd/Linkify/Test/ProcessTest.php
+++ b/tests/Misd/Linkify/Test/ProcessTest.php
@@ -70,12 +70,9 @@ class ProcessTest extends LinkifyTest
      * @test
      * @dataProvider ignoreProvider
      */
-    public function avoidNonLinks(array $data)
+    public function avoidNonLinks(array $options, $test)
     {
-        $linkify = new Linkify($data['options']);
-
-        foreach ($data['tests'] as $test) {
-            $this->assertEquals($test, $linkify->process($test));
-        }
+        $linkify = new Linkify($options);
+        $this->assertEquals($test, $linkify->process($test));
     }
 }

--- a/tests/Misd/Linkify/Test/ProcessUrlsTest.php
+++ b/tests/Misd/Linkify/Test/ProcessUrlsTest.php
@@ -69,12 +69,9 @@ class ProcessUrlsTest extends LinkifyTest
      * @test
      * @dataProvider ignoreProvider
      */
-    public function avoidNonLinks(array $data)
+    public function avoidNonLinks(array $options, $test)
     {
-        $linkify = new Linkify($data['options']);
-
-        foreach ($data['tests'] as $test) {
-            $this->assertEquals($test, $linkify->processUrls($test));
-        }
+        $linkify = new Linkify($options);
+        $this->assertEquals($test, $linkify->processUrls($test));
     }
 }


### PR DESCRIPTION
This makes it easier to deal with failures.

Before, if the first line in the data file failed, none of the subsequent lines would run.
Now every line will always run, and you can get clear output of which ones passed and which ones failed!

If you approve, this could be applied to the other tests to.